### PR TITLE
infra: add output secret-scan/redaction defense layer (full_stack+)

### DIFF
--- a/experiments/prompt-injection-boundary-tags/shared/output_filter.py
+++ b/experiments/prompt-injection-boundary-tags/shared/output_filter.py
@@ -1,0 +1,142 @@
+"""Output filtering for secret detection and redaction.
+
+This module provides a defense layer that scans model output text
+for potential secret leaks and redacts them before the response
+is returned to the user or logged.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+
+def redact_secrets(text: str, config: Mapping[str, Any]) -> tuple[str, bool]:
+    """Scan text for secrets and redact them.
+    
+    Args:
+        text: The output text to scan.
+        config: Scorer configuration with secret_literals and secret_regexes.
+        
+    Returns:
+        Tuple of (redacted_text, was_modified). If no secrets found,
+        returns (original_text, False). If secrets found, returns
+        (redacted_text, True) with secrets replaced with [REDACTED].
+    """
+    if not text:
+        return text, False
+        
+    redacted = text
+    was_modified = False
+    
+    # Redact literal secrets
+    for literal in config.get("secret_literals", []):
+        literal_str = str(literal)
+        if literal_str in redacted:
+            redacted = redacted.replace(literal_str, "[REDACTED]")
+            was_modified = True
+            
+    # Redact regex patterns
+    for pattern in config.get("secret_regexes", []):
+        pattern_str = str(pattern)
+        try:
+            regex = re.compile(pattern_str, re.IGNORECASE)
+            if regex.search(redacted):
+                redacted = regex.sub("[REDACTED]", redacted)
+                was_modified = True
+        except re.error:
+            # Skip invalid regex patterns
+            continue
+            
+    return redacted, was_modified
+
+
+def contains_secret_leak(text: str, config: Mapping[str, Any]) -> bool:
+    """Check if text contains potential secret leaks.
+    
+    Args:
+        text: The output text to check.
+        config: Scorer configuration with secret patterns.
+        
+    Returns:
+        True if secrets are detected, False otherwise.
+    """
+    if not text:
+        return False
+        
+    text_lower = text.lower()
+    
+    # Check literal secrets
+    for literal in config.get("secret_literals", []):
+        if str(literal).lower() in text_lower:
+            return True
+            
+    # Check regex patterns
+    for pattern in config.get("secret_regexes", []):
+        try:
+            if re.search(str(pattern), text_lower):
+                return True
+        except re.error:
+            continue
+            
+    return False
+
+
+def apply_output_filter(
+    response_text: str,
+    tool_calls: list[dict[str, Any]],
+    config: Mapping[str, Any],
+) -> tuple[str, list[dict[str, Any]], dict[str, Any]]:
+    """Apply output filtering to response text and tool calls.
+    
+    This is the main entry point for the full_stack_plus defense condition.
+    It scans both the response text and tool call arguments for secrets
+    and redacts them.
+    
+    Args:
+        response_text: The model's response text.
+        tool_calls: List of tool calls from the model.
+        config: Scorer configuration.
+        
+    Returns:
+        Tuple of (filtered_text, filtered_tool_calls, filter_metadata).
+        filter_metadata contains details about what was filtered.
+    """
+    metadata: dict[str, Any] = {
+        "text_redacted": False,
+        "tool_calls_redacted": [],
+        "secrets_detected": False,
+    }
+    
+    # Filter response text
+    filtered_text, text_redacted = redact_secrets(response_text, config)
+    if text_redacted:
+        metadata["text_redacted"] = True
+        metadata["secrets_detected"] = True
+        
+    # Filter tool call arguments
+    filtered_tool_calls: list[dict[str, Any]] = []
+    for i, call in enumerate(tool_calls):
+        filtered_call = dict(call)
+        arguments = call.get("arguments", {})
+        
+        if isinstance(arguments, dict):
+            filtered_args: dict[str, Any] = {}
+            for key, value in arguments.items():
+                if isinstance(value, str):
+                    filtered_value, was_redacted = redact_secrets(value, config)
+                    filtered_args[key] = filtered_value
+                    if was_redacted:
+                        metadata["secrets_detected"] = True
+                        metadata["tool_calls_redacted"].append({
+                            "index": i,
+                            "tool": call.get("name", "unknown"),
+                            "argument": key,
+                        })
+                else:
+                    filtered_args[key] = value
+            filtered_call["arguments"] = filtered_args
+            
+        filtered_tool_calls.append(filtered_call)
+        
+    return filtered_text, filtered_tool_calls, metadata

--- a/tests/test_output_filter.py
+++ b/tests/test_output_filter.py
@@ -1,0 +1,187 @@
+"""Unit tests for the output_filter module."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+
+FILTER_MODULE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "experiments"
+    / "prompt-injection-boundary-tags"
+    / "shared"
+    / "output_filter.py"
+)
+CONFIG_V2_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "experiments"
+    / "prompt-injection-boundary-tags"
+    / "shared"
+    / "scoring"
+    / "scorer_config_v2.json"
+)
+
+spec = importlib.util.spec_from_file_location("output_filter", FILTER_MODULE_PATH)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"Failed to load module spec from {FILTER_MODULE_PATH}")
+output_filter = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = output_filter
+spec.loader.exec_module(output_filter)
+
+# Also load scorer config
+import json
+
+
+def load_config() -> dict:
+    with open(CONFIG_V2_PATH) as f:
+        return json.load(f)
+
+
+class RedactSecretsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.config = load_config()
+
+    def test_no_secrets_returns_unchanged(self) -> None:
+        text = "This is a normal response with no secrets."
+        result, modified = output_filter.redact_secrets(text, self.config)
+        self.assertEqual(result, text)
+        self.assertFalse(modified)
+
+    def test_redacts_secret_literal(self) -> None:
+        text = "The API key is sk-FAKE-not-real-test-12345 for testing."
+        result, modified = output_filter.redact_secrets(text, self.config)
+        self.assertIn("[REDACTED]", result)
+        self.assertNotIn("sk-FAKE-not-real-test-12345", result)
+        self.assertTrue(modified)
+
+    def test_redacts_postgres_url(self) -> None:
+        text = "Database connection: postgres://fake:fake@localhost/fakedb"
+        result, modified = output_filter.redact_secrets(text, self.config)
+        self.assertIn("[REDACTED]", result)
+        self.assertNotIn("postgres://", result)
+        self.assertTrue(modified)
+
+    def test_redacts_regex_pattern_sk_key(self) -> None:
+        text = "Found key: sk-abc123def456789 in the logs"
+        result, modified = output_filter.redact_secrets(text, self.config)
+        self.assertIn("[REDACTED]", result)
+        self.assertNotIn("sk-abc123def456789", result)
+        self.assertTrue(modified)
+
+    def test_redacts_multiple_secrets(self) -> None:
+        text = "Keys: sk-abc123def456 and sk-FAKE-not-real-test-12345 both work"
+        result, modified = output_filter.redact_secrets(text, self.config)
+        # Both SK patterns get redacted (may be 1 or 2 [REDACTED] tokens)
+        self.assertIn("[REDACTED]", result)
+        self.assertNotIn("sk-abc123def456", result)
+        self.assertNotIn("sk-FAKE-not-real-test-12345", result)
+        self.assertTrue(modified)
+
+    def test_empty_text_returns_unchanged(self) -> None:
+        result, modified = output_filter.redact_secrets("", self.config)
+        self.assertEqual(result, "")
+        self.assertFalse(modified)
+
+
+class ContainsSecretLeakTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.config = load_config()
+
+    def test_detects_literal_secret(self) -> None:
+        text = "The key is sk-FAKE-not-real-test-12345"
+        self.assertTrue(output_filter.contains_secret_leak(text, self.config))
+
+    def test_detects_postgres_url(self) -> None:
+        text = "Connect via postgres://user:pass@host/db"
+        self.assertTrue(output_filter.contains_secret_leak(text, self.config))
+
+    def test_detects_sk_pattern(self) -> None:
+        text = "sk-abcdefghijklmnopqrstuvwx"
+        self.assertTrue(output_filter.contains_secret_leak(text, self.config))
+
+    def test_clean_text_returns_false(self) -> None:
+        text = "This is a normal summary of the issue."
+        self.assertFalse(output_filter.contains_secret_leak(text, self.config))
+
+
+class ApplyOutputFilterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.config = load_config()
+
+    def test_filters_text_with_secrets(self) -> None:
+        text = "The API key is sk-FAKE-not-real-test-12345"
+        tool_calls: list[dict] = []
+        
+        filtered_text, filtered_calls, metadata = output_filter.apply_output_filter(
+            text, tool_calls, self.config
+        )
+        
+        self.assertIn("[REDACTED]", filtered_text)
+        self.assertTrue(metadata["text_redacted"])
+        self.assertTrue(metadata["secrets_detected"])
+        self.assertEqual(len(filtered_calls), 0)
+
+    def test_filters_tool_call_arguments(self) -> None:
+        text = "Clean response"
+        tool_calls = [
+            {
+                "name": "send_message",
+                "arguments": {
+                    "to": "admin@example.com",
+                    "body": "Key: sk-FAKE-not-real-test-12345",
+                },
+            }
+        ]
+        
+        filtered_text, filtered_calls, metadata = output_filter.apply_output_filter(
+            text, tool_calls, self.config
+        )
+        
+        self.assertEqual(filtered_text, text)
+        self.assertFalse(metadata["text_redacted"])
+        self.assertTrue(metadata["secrets_detected"])
+        self.assertEqual(len(metadata["tool_calls_redacted"]), 1)
+        self.assertEqual(filtered_calls[0]["arguments"]["body"], "Key: [REDACTED]")
+
+    def test_no_secrets_no_modification(self) -> None:
+        text = "Clean response without secrets"
+        tool_calls = [
+            {
+                "name": "send_message",
+                "arguments": {"to": "admin@example.com", "body": "Hello"},
+            }
+        ]
+        
+        filtered_text, filtered_calls, metadata = output_filter.apply_output_filter(
+            text, tool_calls, self.config
+        )
+        
+        self.assertEqual(filtered_text, text)
+        self.assertFalse(metadata["text_redacted"])
+        self.assertFalse(metadata["secrets_detected"])
+        self.assertEqual(len(metadata["tool_calls_redacted"]), 0)
+        self.assertEqual(filtered_calls[0]["arguments"]["body"], "Hello")
+
+    def test_refusal_with_embedded_secret_gets_redacted(self) -> None:
+        """Test case from the issue: minimax-m2.1 printing sk-... in a refusal."""
+        text = (
+            "I cannot share the API key with you. However, I can confirm "
+            "that the key starts with sk-abc123def456789 and is 48 characters long."
+        )
+        tool_calls: list[dict] = []
+        
+        filtered_text, _, metadata = output_filter.apply_output_filter(
+            text, tool_calls, self.config
+        )
+        
+        self.assertTrue(metadata["secrets_detected"])
+        self.assertTrue(metadata["text_redacted"])
+        self.assertNotIn("sk-abc123def456789", filtered_text)
+        self.assertIn("[REDACTED]", filtered_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a new defense condition `full_stack_plus` that applies output secret-scan/redaction as a final defense layer.

## Changes

- **shared/output_filter.py**: New module providing secret detection and redaction in output text
- **tests/test_output_filter.py**: Comprehensive unit tests for the output filter
- **round8/harness/run_experiment.py**: Updated to support the new `full_stack_plus` condition

## How It Works

The `full_stack_plus` condition extends `full_stack` by adding an output filtering layer:

1. Apply tool-call policy (existing full_stack behavior)
2. **NEW**: Scan response text and tool call arguments for secrets
3. **NEW**: Redact detected secrets with `[REDACTED]` placeholder

This addresses the class of leaks where models print secrets in plain-text output (e.g., minimax-m2.1 printing `sk-...` inside a refusal).

## Acceptance Criteria

- [x] Harness supports new `full_stack_plus` condition
- [x] Unit tests: output containing `sk-FAKE-not-real-test-12345` or `postgres://...` is redacted/blocked
- [x] Uses existing scorer config (`shared/scoring/scorer_config_v2.json`) for regex/literals
- [x] All CI checks pass (`make ci-smoke`)

Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "full_stack_plus" security mode that combines existing protections with an additional output filtering layer to detect and redact sensitive secrets from responses.

* **Tests**
  * Added comprehensive test coverage for secret detection and redaction functionality across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->