### PR TITLE
ci: add merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - run: |
+      - name: Evaluate ci-smoke result
+        run: |
           if [[ "${{ needs.ci-smoke.result }}" == "success" ]]; then
             echo "merge-gate green"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,17 @@ jobs:
 
       - name: Run smoke checks
         run: make ci-smoke
+
+  merge-gate:
+    name: merge-gate
+    needs: [ci-smoke]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - run: |
+          if [[ "${{ needs.ci-smoke.result }}" == "success" ]]; then
+            echo "merge-gate green"
+          else
+            echo "merge-gate red (ci-smoke=${{ needs.ci-smoke.result }})"
+            exit 1
+          fi

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,27 @@
+name: trufflehog
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  trufflehog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run TruffleHog
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --results=verified,unknown


### PR DESCRIPTION
## Summary
- add a stable `merge-gate` job that aggregates the repo's deterministic CI jobs
- prepare the repo for a single required status check instead of bespoke or multi-check protection
- reduce merge friction without dropping real quality gates

## Why
Org policy is moving toward one required deterministic merge gate per repo. This change keeps the real CI jobs intact, but adds one explicit gate name that branch protection can require without depending on AI review checks or multiple separate required checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a merge validation job that reports a clear pass/fail gate alongside CI, surfacing failures to block merges when prerequisite checks fail.
  * Introduced an automated repository secret scan that runs on PRs and mainline pushes and emits verified/unknown findings to improve security visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->