### PR TITLE
chore: ignore .DS_Store and home comic-ops aesthetic backlog item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 *.pyc
 .env
+.DS_Store
 venv/
 .venv/
 node_modules/

--- a/backlog.d/001-adopt-misty-step-comic-ops-aesthetic.md
+++ b/backlog.d/001-adopt-misty-step-comic-ops-aesthetic.md
@@ -1,0 +1,23 @@
+# Adopt the Misty Step comic-ops aesthetic baseline
+
+Priority: P2 · Status: pending · Estimate: M
+
+## Goal
+Evaluate and adopt the clean-atomic comic-ops flavor for Laboratory experiment
+reports, benchmark summaries, and reproducibility artifacts.
+
+## Oracle
+- [ ] `DESIGN.md` or experiment-template docs name the chosen flavor, likely
+      `clean-atomic`, and the report surfaces it governs.
+- [ ] One representative experiment/report surface is rendered or mocked with
+      run ledgers, confidence intervals, captions, and proof strips.
+- [ ] Aesthetic changes preserve statistical rigor and do not imply conclusions
+      beyond recorded evidence.
+- [ ] The implementation uses `@misty-step/aesthetic` commit `9bbe0f9` or later,
+      or records a deliberate no-adoption decision.
+- [ ] `make ci-smoke` or the repo's current canonical gate passes after
+      implementation.
+
+## Notes
+Reference board:
+`http://serenity.tail5f5eb4.ts.net:8788/laboratory-clean-atomic-concept.png`.


### PR DESCRIPTION
Tidy-up after merging #71.

- Add `.DS_Store` to `.gitignore` (was untracked clutter; the pattern was missing).
- Track `backlog.d/001-adopt-misty-step-comic-ops-aesthetic.md` (was untracked signal — a pending P2 design task that belongs in the tracked backlog).

No code or experiment data touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added macOS Finder metadata files to the ignore list to keep the repository cleaner.
* **Documentation**
  * Added a new backlog note outlining a pending design direction and review checklist for future work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->